### PR TITLE
Fix the `GetQuote` method.

### DIFF
--- a/client.go
+++ b/client.go
@@ -354,17 +354,17 @@ func (c *Client) GetMarkets() ([]Market, error) {
 func (c *Client) GetQuote(id int) (Quote, error) {
 	idStr := strconv.Itoa(id)
 
-	params := url.Values{}
-	params.Add("ids", idStr)
-
 	q := struct {
 		Quotes []Quote `json:"quotes"`
 	}{}
+	//var q2 json.RawMessage
 
-	err := c.get("v1/symbols/quotes?", &q, params)
+	err := c.get("v1/markets/quotes/"+idStr, &q, url.Values{})
 	if err != nil {
 		return Quote{}, err
 	}
+
+	//fmt.Println("RESULT:", string(q2))
 
 	if len(q.Quotes) != 1 {
 		return Quote{}, errors.New("Error: Could not retreive quotes")
@@ -390,7 +390,7 @@ func (c *Client) GetQuotes(ids ...int) ([]Quote, error) {
 		Quotes []Quote `json:"quotes"`
 	}{}
 
-	err := c.get("v1/symbols/quotes?", &q, params)
+	err := c.get("v1/markets/quotes?", &q, params)
 	if err != nil {
 		return []Quote{}, err
 	}

--- a/market.go
+++ b/market.go
@@ -211,10 +211,10 @@ type Market struct {
 // Quote represents a Lvl 1 market data quote for a particular symbol
 type Quote struct {
 	// Symbol name following Questrade’s symbology.
-	Symbol int `json:"symbol"`
+	Symbol string `json:"symbol"`
 
 	// Internal symbol identifier.
-	SymbolID string `json:"symbolId"`
+	SymbolID int `json:"symbolId"`
 
 	// Market tier.
 	Tier string `json:"tier"`
@@ -243,6 +243,9 @@ type Quote struct {
 	// Trade direction.
 	LastTradeTick string `json:"lastTradeTick"`
 
+	// Timestamp
+	LastTtradeTime string `json:"lastTradeTime"`
+
 	// Volume.
 	Volume int `json:"volume"`
 
@@ -256,7 +259,7 @@ type Quote struct {
 	LowPrice float32 `json:"lowPrice"`
 
 	// Whether a quote is delayed (true) or real-time.
-	Delay bool `json:"delay"`
+	Delay int `json:"delay"`
 
 	// Whether trading in the symbol is currently halted.
 	IsHalted bool `json:"isHalted"`


### PR DESCRIPTION
This fixes the `GetQuote` method, and illustrates the errors in http://www.questrade.com/api/documentation/rest-operations/market-calls/markets-quotes-id (symbolId is obviously an int, not a string as they say it is).
