### PR TITLE
README sample fix, QuestradeError readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ again after the current session expires. See http://www.questrade.com/api/docume
 ##Usage
 ```go
 // Create a new client on the practice server
-client, err := qapi.NewClient(“< REFRESH TOKEN >”, true)
+client, err := qapi.NewClient("< REFRESH TOKEN >", true)
 
 // Get accounts
 userId, accts, err := client.GetAccounts()
@@ -25,16 +25,16 @@ userId, accts, err := client.GetAccounts()
 balances, err := client.GetBalances(accts[0].Number)
 
 // Print the market value of the combined balances
-for b := range balances.CombinedBalances {
-    fmt.Printf(“Market Value: $%.2f %s\n”, b.MarketValue, b.Currency)
+for _, b := range balances.CombinedBalances {
+    fmt.Printf("Market Value: $%.2f %s\n", b.MarketValue, b.Currency)
 }
 
 // To get a quote the API uses internal symbol ID’s.
-results, err := client.SearchSymbols(“AAPL”, 0)
+results, err := client.SearchSymbols("AAPL", 0)
 
 var symId int
-for r := range results {
-    if r.Symbol == “AAPL” && r.ListingExchange == “NASDAQ” {
+for _, r := range results {
+    if r.Symbol == "AAPL" && r.ListingExchange == "NASDAQ" {
         symId = r.SymbolID
         break
     }
@@ -42,7 +42,7 @@ for r := range results {
 
 // Get a real-time quote - qapi supports getting quotes of multiple symbols with GetQuotes()
 quote, err := client.GetQuote(symId)
-fmt.Printf(“AAPL Bid Price: $%.2f\n”, quote.BidPrice)
+fmt.Printf("AAPL Bid Price: $%.2f\n", quote.BidPrice)
 
 // Create an order request
 req := qapi.OrderRequest{

--- a/errors.go
+++ b/errors.go
@@ -20,12 +20,8 @@ func newQuestradeError(res *http.Response, body []byte) QuestradeError {
 	var e QuestradeError
 	err := json.Unmarshal(body, &e)
 	if err != nil {
-		return QuestradeError{
-			Code:       -999,
-			Message:    "Error unmarshalling error message from Questrade",
-			StatusCode: res.StatusCode,
-			Endpoint:   res.Request.URL.String(),
-		}
+		e.Code = -999
+		e.Message = string(body)
 	}
 
 	e.StatusCode = res.StatusCode
@@ -35,5 +31,13 @@ func newQuestradeError(res *http.Response, body []byte) QuestradeError {
 }
 
 func (q QuestradeError) Error() string {
-	return fmt.Sprintf("HTTP %d - %s [%d] - %s", q.StatusCode, q.Endpoint, q.Code, q.Message)
+	return fmt.Sprintf("\nQuestradeError:\n" +
+	                   "\tStatus code: HTTP %d\n" +
+	                   "\tEndpoint: %s\n" +
+	                   "\tError code: %d\n" +
+	                   "\tMessage: %s\n",
+	                   q.StatusCode,
+	                   q.Endpoint,
+	                   q.Code,
+	                   q.Message)
 }


### PR DESCRIPTION
About the changes in newQuestradeError: For example if I use an expired token, the http response message won't be in json format so I'll get "Error unmarshalling error message from Questrade", but what I should be getting in the message is "Bad request".


Thanks for making this repo!!